### PR TITLE
Fix: mkdirp を devDependencies から dependencies に移動した

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "writeout",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "argx": "^4.0.4",
     "asleep": "^1.0.3",
-    "filedel": "^4.1.2"
+    "filedel": "^4.1.2",
+    "mkdirp": "^1.0.4"
   },
   "devDependencies": {
     "amocha": "^7.0.2",
@@ -35,8 +36,7 @@
     "ape-tasking": "^4.0.12",
     "ape-tmpl": "^6.0.14",
     "ape-updating": "^5.0.3",
-    "coz": "^7.2.0",
-    "mkdirp": "^1.0.4"
+    "coz": "^7.2.0"
   },
   "engines": {
     "node": ">=7.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "writeout",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Write out string files with various options.",
   "main": "lib",
   "browser": {


### PR DESCRIPTION
@okunishinishi 

依存関係を明示するために mkdirp を devDependencies から dependencies に移動した。

これにより以下の問題が解決される。

コード内で mkdirp を使っているが、dependeicies にない。

https://github.com/okunishinishi/node-writeout/blob/fc981198f23bd44960f38d5de43fc6fba44ab5a1/lib/writeout.js#L40

そのため、`$ npm install writeout mkdirp@0.5.5` などとすると writeout が古い mkdirp を参照してしまう。すると promise が使われないのでディレクトリが作成される前に次の処理に行ってしまう。（それを回避するために asleep(1) しているっぽい）